### PR TITLE
Add New Stickney Layout to the list

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,6 +35,8 @@ The default JIS /kana/ layout has resulted in market failure because /kana/ are 
 
 *** /Buri Cyuutoro/
 
+*** /New Stickney/ - supported in [[https://esrille.github.io/ibus-hiragana/en/layouts.html#new_stickney][IBUS Hiragana]] on Linux.
+
 *** Others
 
 * My Choice


### PR DESCRIPTION
It looks like your repository is on hiatus, but the initial README didn't mention the New Stickney Layout, which has several plus points including fitting on three rows of 10 (leaving aside the misc function keys and numbers):

* https://esrille.github.io/ibus-hiragana/en/layouts.html#new_stickney
* https://github.com/esrille/new-stickney

It drew on the "New JIS" (aka X6004), including using the space bar as a central shift.

Of note this uses the `゛` (dakuten) after a kana to enter a small form kana:

> To enter one of the small "ぁぃぅぇぉゃゅょ", type the corresponding character from "あいうえおやゆよ" and then press `゛`

That would best be handled in the IME, but I think you could fake it with a dead-key like system in a programmable keyboard (in hardware or software), and run this with a traditional unmodified IME which thinks it is getting JIS kana layout.